### PR TITLE
The speak element must designate the SSML namespace

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,4 +39,4 @@ for:
     only:
       - master
 
-  version: 1.2.1
+  version: 1.2.2

--- a/src/Kevsoft.Ssml/Ssml.cs
+++ b/src/Kevsoft.Ssml/Ssml.cs
@@ -69,7 +69,7 @@ namespace Kevsoft.Ssml
             await writer.WriteStartDocumentAsync()
                 .ConfigureAwait(false);
 
-            await writer.WriteStartElementAsync(null, "speak", null)
+            await writer.WriteStartElementAsync(null, "speak", "http://www.w3.org/2001/10/synthesis")
                 .ConfigureAwait(false);
 
             await writer.WriteAttributeStringAsync(null, "version", null, _version)

--- a/tests/Kevsoft.Ssml.Tests/SsmlTests.cs
+++ b/tests/Kevsoft.Ssml.Tests/SsmlTests.cs
@@ -15,7 +15,7 @@ namespace Kevsoft.Ssml.Tests
                 .Say("World")
                 .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Hello World</speak>");
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Hello World</speak>");
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Kevsoft.Ssml.Tests
                 .AsAlias("Bob")
                 .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Hello <sub alias=""Bob"">World</sub></speak>");
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Hello <sub alias=""Bob"">World</sub></speak>");
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace Kevsoft.Ssml.Tests
                 .AsVoice("en-US-Jessa24kRUS")
                 .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Hello <voice name=""en-US-Jessa24kRUS"">World</voice></speak>");
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Hello <voice name=""en-US-Jessa24kRUS"">World</voice></speak>");
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace Kevsoft.Ssml.Tests
                                              .Say("是的，它确实！")
                                              .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""zh-CN"">这样做吗 <break strength=""x-strong"" time=""100ms"" /> 是的，它确实！</speak>");
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""zh-CN"" xmlns=""http://www.w3.org/2001/10/synthesis"">这样做吗 <break strength=""x-strong"" time=""100ms"" /> 是的，它确实！</speak>");
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace Kevsoft.Ssml.Tests
                 .Emphasised()
                 .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Hello <emphasis>World</emphasis></speak>");
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Hello <emphasis>World</emphasis></speak>");
 
         }
 
@@ -75,7 +75,7 @@ namespace Kevsoft.Ssml.Tests
                 .Emphasised(level)
                 .ToStringAsync();
 
-            xml.Should().Be($@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Hello <emphasis level=""{expected}"">World</emphasis></speak>");
+            xml.Should().Be($@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Hello <emphasis level=""{expected}"">World</emphasis></speak>");
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Kevsoft.Ssml.Tests
                 .Say("then continue.")
                 .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Take a deep breath <break /> then continue.</speak>");
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Take a deep breath <break /> then continue.</speak>");
         }
 
         [Theory]
@@ -103,7 +103,7 @@ namespace Kevsoft.Ssml.Tests
                 .Say("then continue.")
                 .ToStringAsync();
 
-            xml.Should().Be($@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Take a deep breath <break strength=""{expected}"" /> then continue.</speak>");
+            xml.Should().Be($@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Take a deep breath <break strength=""{expected}"" /> then continue.</speak>");
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace Kevsoft.Ssml.Tests
                 .Say("then continue.")
                 .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Take a deep breath <break time=""1500ms"" /> then continue.</speak>");
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Take a deep breath <break time=""1500ms"" /> then continue.</speak>");
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Kevsoft.Ssml.Tests
                 .Say("then continue.")
                 .ToStringAsync();
 
-            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Take a deep breath <break strength=""x-strong"" time=""100ms"" /> then continue.</speak>");        }
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Take a deep breath <break strength=""x-strong"" time=""100ms"" /> then continue.</speak>");        }
 
         [Fact]
         public async Task ShouldReturnSayAsWhenSayingADate()
@@ -138,7 +138,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    $@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">This code was written on <say-as interpret-as=""date"">{
+                    $@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">This code was written on <say-as interpret-as=""date"">{
                             date
                         :yyyyMMdd}</say-as></speak>");
         }
@@ -181,7 +181,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    $@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">This code was written on <say-as interpret-as=""date"" format=""{
+                    $@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">This code was written on <say-as interpret-as=""date"" format=""{
                             format
                         }"">{expectedDate}</say-as></speak>");
         }
@@ -215,7 +215,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Bedtime is <say-as interpret-as=""time"" format=""hms24"">20:05:33</say-as></speak>");
+                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Bedtime is <say-as interpret-as=""time"" format=""hms24"">20:05:33</say-as></speak>");
         }
 
 
@@ -230,7 +230,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">Bedtime is <say-as interpret-as=""time"" format=""hms12"">08:05:33PM</say-as></speak>");
+                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Bedtime is <say-as interpret-as=""time"" format=""hms12"">08:05:33PM</say-as></speak>");
         }
 
         [Fact]
@@ -243,7 +243,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">If you require a new job, please phone <say-as interpret-as=""telephone"">+44 (0)114 273 0281</say-as></speak>");
+                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">If you require a new job, please phone <say-as interpret-as=""telephone"">+44 (0)114 273 0281</say-as></speak>");
         }
 
         [Fact]
@@ -256,7 +256,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">It's as easy as <say-as interpret-as=""characters"" format=""characters"">abc</say-as></speak>");
+                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">It's as easy as <say-as interpret-as=""characters"" format=""characters"">abc</say-as></speak>");
         }
 
         [Fact]
@@ -269,7 +269,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">It's as easy as <say-as interpret-as=""characters"" format=""glyph"">abc</say-as></speak>");
+                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">It's as easy as <say-as interpret-as=""characters"" format=""glyph"">abc</say-as></speak>");
         }
 
         [Fact]
@@ -282,7 +282,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">We only have <say-as interpret-as=""cardinal"">512</say-as></speak>");
+                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">We only have <say-as interpret-as=""cardinal"">512</say-as></speak>");
         }
 
         [Fact]
@@ -295,7 +295,7 @@ namespace Kevsoft.Ssml.Tests
 
             xml.Should()
                 .Be(
-                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"">We only have <say-as interpret-as=""ordinal"">512</say-as></speak>");
+                    @"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">We only have <say-as interpret-as=""ordinal"">512</say-as></speak>");
         }
     }
 }


### PR DESCRIPTION
From the SSML spec: ["The `speak` element must designate the SSML namespace"](https://www.w3.org/TR/speech-synthesis11/#S2.1)

