### PR TITLE
Support IFluentSay method composition

### DIFF
--- a/src/Kevsoft.Ssml/FluentFluentSay.cs
+++ b/src/Kevsoft.Ssml/FluentFluentSay.cs
@@ -22,33 +22,33 @@ namespace Kevsoft.Ssml
                 .ConfigureAwait(false);
         }
 
-        public ISsml AsAlias(string alias)
+        public IFluentSay AsAlias(string alias)
         {
             _ssmlWriter = new SubWriter(_ssmlWriter, alias);
 
             return this;
         }
 
-        public ISsml AsVoice(string name)
+        public IFluentSay AsVoice(string name)
         {
             _ssmlWriter = new VoiceWriter(_ssmlWriter, name);
 
             return this;
         }
 
-        public ISsml Emphasised()
+        public IFluentSay Emphasised()
         {
             return Emphasised(EmphasiseLevel.NotSet);
         }
 
-        public ISsml Emphasised(EmphasiseLevel level)
+        public IFluentSay Emphasised(EmphasiseLevel level)
         {
             _ssmlWriter = new EmphasiseWriter(_ssmlWriter, level);
 
             return this;
         }
 
-        public ISsml AsTelephone()
+        public IFluentSay AsTelephone()
         {
             _ssmlWriter = new SayAsWriter("telephone", _value);
 

--- a/src/Kevsoft.Ssml/IFluentSay.cs
+++ b/src/Kevsoft.Ssml/IFluentSay.cs
@@ -4,14 +4,14 @@ namespace Kevsoft.Ssml
 {
     public interface IFluentSay : ISsml
     {
-        ISsml AsAlias(string alias);
-        ISsml AsVoice(string name);
+        IFluentSay AsAlias(string alias);
+        IFluentSay AsVoice(string name);
 
-        ISsml Emphasised();
+        IFluentSay Emphasised();
 
-        ISsml Emphasised(EmphasiseLevel level);
+        IFluentSay Emphasised(EmphasiseLevel level);
 
-        ISsml AsTelephone();
+        IFluentSay AsTelephone();
 
         IFluentSayAsCharaters AsCharacters();
     }

--- a/tests/Kevsoft.Ssml.Tests/SsmlTests.cs
+++ b/tests/Kevsoft.Ssml.Tests/SsmlTests.cs
@@ -41,6 +41,18 @@ namespace Kevsoft.Ssml.Tests
         }
 
         [Fact]
+        public async Task ShouldReturnEmphasisedSpeakWithTextForVoice()
+        {
+            var xml = await new Ssml().Say("Hello")
+                .Say("World")
+                .Emphasised()
+                .AsVoice("en-US-Jessa24kRUS")
+                .ToStringAsync();
+
+            xml.Should().Be(@"<?xml version=""1.0"" encoding=""utf-16""?><speak version=""1.0"" xml:lang=""en-US"" xmlns=""http://www.w3.org/2001/10/synthesis"">Hello <voice name=""en-US-Jessa24kRUS""><emphasis>World</emphasis></voice></speak>");
+        }
+
+        [Fact]
         public async Task ShouldReturnChineseLanguageSsml()
         {
             var xml = await new Ssml(lang: "zh-CN").Say("这样做吗")


### PR DESCRIPTION
The methods in `IFluentSay` return `ISsml` so they cannot be composed. For example, `ssml.Say("Hello").Emphasised().AsVoice("en-US-Jessa24kRUS")`, is not possible.

Changing the methods to return `IFluentSay` instead, makes composition possible.