### PR TITLE
Embed license file and use SourceLink

### DIFF
--- a/src/Kevsoft.Ssml/Kevsoft.Ssml.csproj
+++ b/src/Kevsoft.Ssml/Kevsoft.Ssml.csproj
@@ -21,9 +21,19 @@
   <PropertyGroup>
     <PackageVersion>1.0.0</PackageVersion>
     <PackageTags>SSML;XML Generator;Speech Synthesis Markup Language;Amazon;Alexa;</PackageTags>
-    <PackageProjectUrl>https://github.com/kevbite/Kevsoft.SSML</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/kevbite/Kevsoft.SSML</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Modernizing a bit the NuGet packaging...

Embedding the license file will remove the warning when uploading to nuget.org.

[SourceLink](https://github.com/dotnet/sourcelink) automatically sets the repository type and URL. Also allows source stepping when debugging client projects. The reference is added as private so no dependencies are added to the package.