### PR TITLE
Additional method called ForAlexa added as SSML for Alexa Skills does…

### DIFF
--- a/src/Kevsoft.Ssml/FluentSsml.cs
+++ b/src/Kevsoft.Ssml/FluentSsml.cs
@@ -12,6 +12,11 @@ namespace Kevsoft.Ssml
             _inner = inner;
         }
 
+        ISsml ISsml.ForAlexa()
+        {
+            return _inner.ForAlexa();
+        }
+
         IFluentSay ISsml.Say(string value)
         {
             return _inner.Say(value);

--- a/src/Kevsoft.Ssml/ISsml.cs
+++ b/src/Kevsoft.Ssml/ISsml.cs
@@ -5,6 +5,8 @@ namespace Kevsoft.Ssml
 {
     public interface ISsml
     {
+        ISsml ForAlexa();
+
         IFluentSay Say(string value);
 
         IFluentSayDate Say(DateTime value);

--- a/src/Kevsoft.Ssml/Ssml.cs
+++ b/src/Kevsoft.Ssml/Ssml.cs
@@ -11,11 +11,18 @@ namespace Kevsoft.Ssml
         private readonly List<ISsmlWriter> _says = new List<ISsmlWriter>();
         private readonly string _lang;
         private readonly string _version;
+        private bool _forAlexa { get; set; }
 
         public Ssml(string lang = "en-US", string version = "1.0")
         {
             _lang = lang;
             _version = version;
+        }
+
+        public ISsml ForAlexa()
+        {
+            _forAlexa = true;
+            return this;
         }
 
         public IFluentSay Say(string value)
@@ -72,8 +79,11 @@ namespace Kevsoft.Ssml
             await writer.WriteStartElementAsync(null, "speak", "http://www.w3.org/2001/10/synthesis")
                 .ConfigureAwait(false);
 
-            await writer.WriteAttributeStringAsync(null, "version", null, _version)
-                .ConfigureAwait(false);
+            if (!_forAlexa)
+            {
+                await writer.WriteAttributeStringAsync(null, "version", null, _version)
+                    .ConfigureAwait(false);
+            }
 
             await writer.WriteAttributeStringAsync("xml", "lang", null, _lang)
                         .ConfigureAwait(false);


### PR DESCRIPTION
… not allow for a version attribute on the speak tag on the XML. Using this methods makes sure that it is omitted